### PR TITLE
EIP-131: Fix obs-to-odoo-resource route to safely handle obsgroup/any obs with null value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
      <repository>
          <id>openmrs-repo</id>
          <name>OpenMRS Nexus Repository</name>
-         <url>http://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
+         <url>https://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
      </repository>
   </repositories>
 

--- a/src/main/resources/camel/obs/obs-to-odoo-resource.xml
+++ b/src/main/resources/camel/obs/obs-to-odoo-resource.xml
@@ -103,7 +103,7 @@
                 <choice>
                     <when>
                         <spel>#{getProperty('obsQnAnsMap').containsKey(getProperty('obsQnUuid')) &amp;&amp; getProperty('entity-instance').get('value') != null}</spel>
-                        <!--in case of obsgroup usage the value can be null-->
+                        <!--Skip obs with null value, this could be an obsgroup-->
                         <log loggingLevel="DEBUG" message="Obs has configured question concept and non null value" />
 
                         <choice>

--- a/src/main/resources/camel/obs/obs-to-odoo-resource.xml
+++ b/src/main/resources/camel/obs/obs-to-odoo-resource.xml
@@ -123,7 +123,7 @@
                         <choice>
                             <when>
                                 <spel>#{getProperty('entity-instance').get('value') == null}</spel>
-                                <log loggingLevel="DEBUG" message="Skipping obs because the value is null" />
+                                <log loggingLevel="DEBUG" message="Skipping obs because it's value is null" />
                             </when>
                             <otherwise>
                                 <log loggingLevel="DEBUG" message="Skipping Obs because the question concept doesn't match any configured question" />

--- a/src/main/resources/camel/obs/obs-to-odoo-resource.xml
+++ b/src/main/resources/camel/obs/obs-to-odoo-resource.xml
@@ -120,7 +120,16 @@
                         </choice>
                     </when>
                     <otherwise>
-                        <log loggingLevel="DEBUG" message="Skipping Obs because the question concept doesn't match any configured question or is null" />
+                        <choice>
+                            <when>
+                                <spel>#{getProperty('entity-instance').get('value') == null}</spel>
+                                <log loggingLevel="DEBUG" message="Skipping obs because the value is null" />
+                            </when>
+                            <otherwise>
+                                <log loggingLevel="DEBUG" message="Skipping Obs because the question concept doesn't match any configured question" />
+                            </otherwise>
+                        </choice>
+
                     </otherwise>
                 </choice>
             </when>

--- a/src/main/resources/camel/obs/obs-to-odoo-resource.xml
+++ b/src/main/resources/camel/obs/obs-to-odoo-resource.xml
@@ -102,9 +102,9 @@
 
                 <choice>
                     <when>
-                        <spel>#{getProperty('obsQnAnsMap').containsKey(getProperty('obsQnUuid'))}</spel>
-
-                        <log loggingLevel="DEBUG" message="Obs has configured question concept" />
+                        <spel>#{getProperty('obsQnAnsMap').containsKey(getProperty('obsQnUuid')) &amp;&amp; getProperty('entity-instance').get('value') != null}</spel>
+                        <!--in case of obsgroup usage the value can be null-->
+                        <log loggingLevel="DEBUG" message="Obs has configured question concept and non null value" />
 
                         <choice>
                             <when>
@@ -120,7 +120,7 @@
                         </choice>
                     </when>
                     <otherwise>
-                        <log loggingLevel="DEBUG" message="Skipping Obs because the question concept doesn't match any configured question" />
+                        <log loggingLevel="DEBUG" message="Skipping Obs because the question concept doesn't match any configured question or is null" />
                     </otherwise>
                 </choice>
             </when>

--- a/src/test/java/com/mekomsolutions/eip/route/obs/ObsToOdooResourceRouteTest.java
+++ b/src/test/java/com/mekomsolutions/eip/route/obs/ObsToOdooResourceRouteTest.java
@@ -148,7 +148,7 @@ public class ObsToOdooResourceRouteTest extends BaseOdooRouteTest {
 		producerTemplate.send(URI_OBS_TO_ODOO_RESOURCE, exchange);
 
 		mockObsToOdooResHandlerEndpoint.assertIsSatisfied();
-		assertMessageLogged(Level.DEBUG, "Skipping obs because the value is null");
+		assertMessageLogged(Level.DEBUG, "Skipping obs because it's value is null");
 	}
 	
 	@Test

--- a/src/test/java/com/mekomsolutions/eip/route/obs/ObsToOdooResourceRouteTest.java
+++ b/src/test/java/com/mekomsolutions/eip/route/obs/ObsToOdooResourceRouteTest.java
@@ -132,6 +132,24 @@ public class ObsToOdooResourceRouteTest extends BaseOdooRouteTest {
 		Assert.assertTrue(obsQnAnsMap.get(CONCEPT_UUID_2).contains(CONCEPT_UUID_B));
 		Assert.assertTrue(obsQnAnsMap.get(CONCEPT_UUID_2).contains(CONCEPT_UUID_C));
 	}
+
+	@Test
+	public void shouldSkipAnObsWithANullValue() throws Exception {
+		Exchange exchange = new DefaultExchange(camelContext);
+		Event event = createEvent(TABLE, "1", OBS_UUID, "c");
+		exchange.setProperty(PROP_EVENT, event);
+		Map obsResource = new HashMap();
+		obsResource.put("uuid", OBS_UUID);
+		obsResource.put("concept", singletonMap("uuid", CONCEPT_UUID_1));
+		obsResource.put("value",null);
+		exchange.setProperty(EX_PROP_ENTITY, obsResource);
+		mockObsToOdooResHandlerEndpoint.expectedMessageCount(0);
+
+		producerTemplate.send(URI_OBS_TO_ODOO_RESOURCE, exchange);
+
+		mockObsToOdooResHandlerEndpoint.assertIsSatisfied();
+		assertMessageLogged(Level.DEBUG, "Skipping obs because the value is null");
+	}
 	
 	@Test
 	public void shouldProcessAnObsUpdateEvent() throws Exception {
@@ -217,6 +235,7 @@ public class ObsToOdooResourceRouteTest extends BaseOdooRouteTest {
 		exchange.setProperty(PROP_EVENT, event);
 		Map obsResource = new HashMap();
 		obsResource.put("uuid", OBS_UUID);
+		obsResource.put("value", singletonMap("uuid", CONCEPT_UUID_A));
 		obsResource.put("concept", singletonMap("uuid", "some-question-concept-uuid"));
 		exchange.setProperty(EX_PROP_ENTITY, obsResource);
 		mockObsToOdooResHandlerEndpoint.expectedMessageCount(0);


### PR DESCRIPTION
Ticket: https://issues.openmrs.org/browse/EIP-131

In this case, the obs value of the obsgroup observation is null.
It will produce this error in eip:

```
category=watcher-error-handler Cause: EL1011E: Method call: Attempted to call method get(java.lang.String) on null context object
```